### PR TITLE
Added NuakeLocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This plugin follows the standard runtime path structure.
    inoremap <F4> <C-\><C-n>:Nuake<CR>
    tnoremap <F4> <C-\><C-n>:Nuake<CR>
    ```
+- Run `:NuakeLocal` to open Nuake in the current window.
 
 ## Configuration
 You can tweak the behavior of Nuake by setting a few variables in your `~/.config/nvim/init.vim` file.

--- a/autoload/nuake.vim
+++ b/autoload/nuake.vim
@@ -11,10 +11,12 @@ function! nuake#ToggleWindow() abort "{{{2
 	endif
 endfunction
 
-function! s:OpenWindow() abort "{{{2
-	let l:nuake_buf_nr = bufnr(s:NuakeBufNr())
+function! nuake#Window() abort "{{{2
+	call s:OpenWindowLocal()
+endfunction
 
-	execute  'silent keepalt ' . s:NuakeLook() . 'split'
+function! s:OpenWindowLocal() abort "{{{2
+	let l:nuake_buf_nr = bufnr(s:NuakeBufNr())
 
 	if l:nuake_buf_nr != -1
 		execute  'buffer ' . l:nuake_buf_nr
@@ -26,6 +28,11 @@ function! s:OpenWindow() abort "{{{2
 		call s:NuakeBufNr()
 	endif
 
+endfunction
+
+function! s:OpenWindow() abort "{{{2
+	execute  'silent keepalt ' . s:NuakeLook() . 'split'
+	call s:OpenWindowLocal()
 endfunction
 
 function! s:InitWindow() abort "{{{2

--- a/doc/nuake.txt
+++ b/doc/nuake.txt
@@ -34,6 +34,8 @@ Add the following into your |init.vim| to toggle Nuake with <F4>:
     inoremap <F4> <C-\><C-n>:Nuake<CR>
     tnoremap <F4> <C-\><C-n>:Nuake<CR>
 
+Run |:NuakeLocal| to open Nuake in the current window.
+
 ==============================================================================
 3. Configuration                                         *nuake-configuration*
 

--- a/plugin/nuake.vim
+++ b/plugin/nuake.vim
@@ -22,6 +22,7 @@ endfor
 
 " Commands {{{1
 command! -nargs=0 Nuake call nuake#ToggleWindow()
+command! -nargs=0 NuakeLocal call nuake#Window()
 
 " Modeline {{{1
 " vim: ts=4 sw=4 sts=4 noet foldenable foldmethod=marker


### PR DESCRIPTION
Command to open Nuake in the current window. This is useful if you want multiple views into the same terminal or to open nuake in a different position than the value of g:nuake_position. NuakeLocal probably isn't the best name for this command, but I couldn't think of a better one. This could also be implemented as an optional argument to Nuake.

By default, running NuakeLocal in the only window will close vim. See #4.