### PR TITLE
Terminal flickering when scrolloff is not zero

### DIFF
--- a/autoload/nuake.vim
+++ b/autoload/nuake.vim
@@ -46,6 +46,7 @@ function! s:InitWindow() abort "{{{2
 	setlocal norelativenumber
 	setlocal nofoldenable
 	setlocal foldcolumn=0
+	setlocal scrolloff=0
 endfunction
 
 function! s:CloseWindow() abort "{{{2


### PR DESCRIPTION
I was getting some flickering when using Nuake, I think it was because `scrolloff` was set to 5. Setting it locally to zero fix flickering if global `scrolloff` is not zero. 