### PR TITLE
Add g:nuake_shell option

### DIFF
--- a/autoload/nuake.vim
+++ b/autoload/nuake.vim
@@ -19,9 +19,9 @@ function! s:OpenWindow() abort "{{{2
     if l:nuake_buf_nr != -1
         execute  'buffer ' . l:nuake_buf_nr
     else
-        let l:vim_options = has('terminal') ? '++curwin ++kill=kill' : ''
+        let l:vim_options = has('terminal') ? ' ++curwin ++kill=kill' : ''
 
-        execute  'terminal' . l:vim_options
+        execute  'terminal ' . g:nuake_shell . l:vim_options
         call s:InitWindow()
         call s:NuakeBufNr()
     endif

--- a/plugin/nuake.vim
+++ b/plugin/nuake.vim
@@ -9,6 +9,7 @@ if !has('nvim') && !has('patch-8.0.1593')
 endif
 
 let s:options = [
+            \ ['shell', &shell],
             \ ['position', 'bottom'],
             \ ['size', 0.25],
             \ ['per_tab', 0],


### PR DESCRIPTION
I wanted to use `set shell=/bin/bash` but use `/usr/local/bin/fish` in Nuake.
Now `g:nuake_shell` can be set to the shell of choice for Nuake while using bash for terminal commands outside of Nuake.